### PR TITLE
fix usage as dependency in other WASM projects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ wasm-bindgen = "0.2.58"
 [lib]
 
 #[cfg(target_arch = "wasm32")]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
The problem was that I could not use this library as a dependency for my own WASM library, because it was missing the correct crate type for this kind of situation. I added it, and now it works for me.